### PR TITLE
Add missing fields to `package.json` to fix Vite warning

### DIFF
--- a/packages/svelte-fullcalendar/package.json
+++ b/packages/svelte-fullcalendar/package.json
@@ -28,6 +28,8 @@
 		"type": "git",
 		"url": "git+https://github.com/YogliB/svelte-fullcalendar.git"
 	},
+	"type": "module",
+	"main": "index.js",
 	"svelte": "index.js",
 	"version": "1.1.1"
 }


### PR DESCRIPTION
Vite can't figure out what the package entry point is and is complaining about it