### PR TITLE
Fix #804

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ const config = {
 +	},
 +	optimizeDeps: {
 +		include: ['@fullcalendar/common'],
-+	}
++	},
++ ssr: {
++   noExternal: ['@fullcalendar/core']
++ }
 };
 
 export default config;
@@ -58,6 +61,7 @@ You may then begin to write a parent component that leverages the `FullCalendar`
 
 ```html
 <script lang="ts">
+  import '@fullcalendar/core/vdom';
   import FullCalendar, { type CalendarOptions } from 'svelte-fullcalendar';
   import daygridPlugin from '@fullcalendar/daygrid';
 
@@ -102,6 +106,7 @@ You can modify your calendar’s options after initialization by reassigning the
 
 ```html
 <script>
+  import '@fullcalendar/core/vdom';
   import FullCalendar from 'svelte-fullcalendar';
 
   let options = {
@@ -153,6 +158,7 @@ How do you use [FullCalendar Scheduler's](https://fullcalendar.io/docs/premium) 
 
 ```html
 <script>
+  import '@fullcalendar/core/vdom';
   import FullCalendar from 'svelte-fullcalendar';
   import resourceTimelinePlugin from '@fullcalendar/resource-timeline';
 
@@ -181,10 +187,11 @@ Here is a simple usage example:
 
 ```html
 <script>
+  import '@fullcalendar/core/vdom';
   import FullCalendar, { Draggable } from 'svelte-fullcalendar';
   import resourceTimelinePlugin from '@fullcalendar/resource-timeline';
   import interactionPlugin from '@fullcalendar/interaction';
-  
+
   let options = {
     schedulerLicenseKey: "XXX",
     plugins: [resourceTimelinePlugin, interactionPlugin],

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ const config = {
 +	optimizeDeps: {
 +		include: ['@fullcalendar/common'],
 +	},
-+ ssr: {
-+   noExternal: ['@fullcalendar/core']
-+ }
++	ssr: {
++		noExternal: ['@fullcalendar/core']
++	}
 };
 
 export default config;

--- a/examples/kit/src/routes/index.svelte
+++ b/examples/kit/src/routes/index.svelte
@@ -1,4 +1,5 @@
 <script>
+	import '@fullcalendar/core/vdom';
 	import FullCalendar, { Draggable } from 'svelte-fullcalendar';
 	import daygridPlugin from '@fullcalendar/daygrid';
 	import timegridPlugin from '@fullcalendar/timegrid';

--- a/examples/kit/vite.config.js
+++ b/examples/kit/vite.config.js
@@ -9,6 +9,9 @@ const config = {
 	optimizeDeps: {
 		include: ['@fullcalendar/common'],
 	},
+  ssr: {
+    noExternal: ['@fullcalendar/core']
+  },
 	server: {
 		port: 3000,
 	}


### PR DESCRIPTION
## Motivation

Fix #804 `Please import the top-level fullcalendar lib before attempting to import a plugin.` 
based on [#804 Comment](https://github.com/YogliB/svelte-fullcalendar/issues/804#issuecomment-1330191904)
